### PR TITLE
Added the possibility to start at other positions than the top left corner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,14 +14,14 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { url "https://jitpack.io" }
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 }
 
 ext {
-    compileSdkVersion = 23
-    buildToolsVersion = '23.0.1'
-    targetSdkVersion = 23
+    compileSdkVersion = 24
+    buildToolsVersion = '23.0.3'
+    targetSdkVersion = 24
     minSdkVersion = 14
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 31 17:33:25 JST 2015
+#Thu Aug 11 02:22:07 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:24.1.1'
 }
 
 // build a jar with source files

--- a/library/src/main/java/jp/co/recruit_lifestyle/android/floatingview/FloatingView.java
+++ b/library/src/main/java/jp/co/recruit_lifestyle/android/floatingview/FloatingView.java
@@ -46,7 +46,7 @@ import java.lang.ref.WeakReference;
  * http://stackoverflow.com/questions/18503050/how-to-create-draggabble-system-alert-in-android
  * FIXME:Nexus5＋YouTubeアプリの場合にナビゲーションバーよりも前面に出てきてしまう
  */
-class FloatingView extends FrameLayout implements ViewTreeObserver.OnPreDrawListener {
+public class FloatingView extends FrameLayout implements ViewTreeObserver.OnPreDrawListener {
 
     /**
      * Min Threshold to move in dp
@@ -162,7 +162,7 @@ class FloatingView extends FrameLayout implements ViewTreeObserver.OnPreDrawList
     private int mInitY;
 
 
-    public void setAnimateInitialMove(boolean animateInitialMove) {
+    protected void setAnimateInitialMove(boolean animateInitialMove) {
         this.mAnimateInitialMove = animateInitialMove;
     }
 

--- a/library/src/main/java/jp/co/recruit_lifestyle/android/floatingview/FloatingViewManager.java
+++ b/library/src/main/java/jp/co/recruit_lifestyle/android/floatingview/FloatingViewManager.java
@@ -396,26 +396,26 @@ public class FloatingViewManager implements ScreenChangedListener, View.OnTouchL
      * @param overMargin マージン
      */
     @Deprecated
-    public void addViewToWindow(View view, float shape, int overMargin) {
+    public FloatingView addViewToWindow(View view, float shape, int overMargin) {
         final Options options = new Options();
         options.shape = shape;
         options.overMargin = overMargin;
-        addViewToWindow(view, options);
+        return addViewToWindow(view, options);
     }
 
     /**
      * ViewをWindowに貼り付けます。
-     *
-     * @param view    フローティングさせるView
+     *  @param view    フローティングさせるView
      * @param options Options
      */
-    public void addViewToWindow(View view, Options options) {
+    public FloatingView addViewToWindow(View view, Options options) {
         final boolean isFirstAttach = mFloatingViewList.isEmpty();
         // FloatingView
         final FloatingView floatingView = new FloatingView(mContext);
         floatingView.setInitCoords(options.floatingViewX, options.floatingViewY);
         floatingView.setOnTouchListener(this);
         floatingView.setShape(options.shape);
+        floatingView.setAnimateInitialMove(options.animateInitialMove);
         floatingView.setOverMargin(options.overMargin);
         floatingView.setMoveDirection(options.moveDirection);
         floatingView.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
@@ -446,6 +446,7 @@ public class FloatingViewManager implements ScreenChangedListener, View.OnTouchL
         }
         // 必ずトップに来て欲しいので毎回貼り付け
         mWindowManager.addView(mTrashView, mTrashView.getWindowLayoutParams());
+        return floatingView;
     }
 
     /**
@@ -515,6 +516,7 @@ public class FloatingViewManager implements ScreenChangedListener, View.OnTouchL
          * ※座標を指定すると自動的にMOVE_DIRECTION_NONEになります
          */
         public int moveDirection;
+        public boolean animateInitialMove;
 
         /**
          * オプションのデフォルト値を設定します。
@@ -525,6 +527,7 @@ public class FloatingViewManager implements ScreenChangedListener, View.OnTouchL
             floatingViewX = FloatingView.DEFAULT_X;
             floatingViewY = FloatingView.DEFAULT_Y;
             moveDirection = MOVE_DIRECTION_DEFAULT;
+            animateInitialMove = true;
         }
 
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:24.1.1'
     compile project(':library')
-    compile 'com.google.android.gms:play-services:7.5.0'
+    compile 'com.google.android.gms:play-services:9.4.0'
 }

--- a/sample/src/main/java/jp/co/recruit_lifestyle/sample/service/ChatHeadService.java
+++ b/sample/src/main/java/jp/co/recruit_lifestyle/sample/service/ChatHeadService.java
@@ -64,6 +64,7 @@ public class ChatHeadService extends Service implements FloatingViewListener {
         mChatHeadServiceBinder = new ChatHeadServiceBinder(this);
         final LayoutInflater inflater = LayoutInflater.from(this);
         final ImageView iconView = (ImageView) inflater.inflate(R.layout.widget_chathead, null, false);
+
         iconView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -77,6 +78,11 @@ public class ChatHeadService extends Service implements FloatingViewListener {
         final FloatingViewManager.Options options = new FloatingViewManager.Options();
         options.shape = FloatingViewManager.SHAPE_CIRCLE;
         options.overMargin = (int) (16 * metrics.density);
+
+        options.animateInitialMove = true;
+        options.floatingViewX = metrics.widthPixels; // Spawn on the right side. If we set it outside of bounds, it will animate in.
+        options.floatingViewY = (int)((float)metrics.heightPixels * 0.33); // Start at 33% from the top.
+
         mFloatingViewManager.addViewToWindow(iconView, options);
 
         // 常駐起動

--- a/sample/src/main/res/values-ja/strings.xml
+++ b/sample/src/main/res/values-ja/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+    <string name="app_name">FloatingView Sample</string>
+    <string name="chathead_content_title">デモチャット：アクティブ</string>
+    <string name="chathead_content_text">デモ実行中</string>
+    <string name="ad_content_title">デモ広告：アクティブ</string>
+    <string name="ad_content_text">デモ実行中</string>
+    <string name="charhead_click_message">クリック!</string>
+    <string name="error_load_ad">広告が読み込めなかったか、string.xmlの広告ユニットIDが正しく設定されていません</string>
+    <string name="ad_click_message">3秒後に広告アイコンが表示されます</string>
+    <string name="delete_demo">デモ表示を削除</string>
+    <string name="show_demo">デモ表示</string>
+    <string name="show_ad">広告表示</string>
+    <string name="permission_denied">オーバレイの許可が出ませんでした</string>
+</resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,15 +1,15 @@
 <resources>
     <string name="app_name">FloatingView Sample</string>
-    <string name="chathead_content_title">デモチャット：アクティブ</string>
-    <string name="chathead_content_text">デモ実行中</string>
-    <string name="ad_content_title">デモ広告：アクティブ</string>
-    <string name="ad_content_text">デモ実行中</string>
-    <string name="charhead_click_message">クリック!</string>
-    <string name="error_load_ad">広告が読み込めなかったか、string.xmlの広告ユニットIDが正しく設定されていません</string>
-    <string name="ad_click_message">3秒後に広告アイコンが表示されます</string>
-    <string name="delete_demo">デモ表示を削除</string>
-    <string name="show_demo">デモ表示</string>
-    <string name="show_ad">広告表示</string>
-    <string name="ad_unit_id">ADD_YOUR_UNIT_ID</string>
-    <string name="permission_denied">オーバレイの許可が出ませんでした</string>
+    <string name="chathead_content_title">Demo Chat: Active</string>
+    <string name="chathead_content_text">Demo running.</string>
+    <string name="ad_content_title">Demo Ad active</string>
+    <string name="ad_content_text">Demo running.</string>
+    <string name="charhead_click_message">Click</string>
+    <string name="error_load_ad">Error loading Ad. Check ad unit ID in strings.xml.</string>
+    <string name="ad_click_message">Ad clicked. Showing it after 3 seconds. </string>
+    <string name="delete_demo">App icon deleted.</string>
+    <string name="show_demo">Show Floating Demo</string>
+    <string name="show_ad">Show Ad</string>
+    <string name="ad_unit_id" translatable="false">ADD_YOUR_UNIT_ID</string>
+    <string name="permission_denied">Overlay permission not granted.</string>
 </resources>


### PR DESCRIPTION
We needed to start somewhere else (see the new service implementation) but this option always disabled the animations implicitly.
I may have broken something else along the way (it's not tested completely), I just wanted to let you know this exists now.
Also I translated some stuff, like the strings, to English.

Great animations. 👍 Thank you.
We will use the lib in Messenger for Pokemon GO starting from the next version. 
https://play.google.com/store/apps/details?id=com.shadoweinhorn.messenger
When I find the time, I want to build some kinetics into it, so that you can flip the bubble (I've seen your todo about the y-axis. This. :) )
