### PR TITLE
Enable hardware acceleration by default

### DIFF
--- a/library/src/main/java/jp/co/recruit_lifestyle/android/floatingview/FloatingView.java
+++ b/library/src/main/java/jp/co/recruit_lifestyle/android/floatingview/FloatingView.java
@@ -427,7 +427,8 @@ class FloatingView extends FrameLayout implements ViewTreeObserver.OnPreDrawList
         mParams.type = OVERLAY_TYPE;
         mParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS |
-                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL;
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL |
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED;
         mParams.format = PixelFormat.TRANSLUCENT;
         // 左下の座標を0とする
         mParams.gravity = Gravity.LEFT | Gravity.BOTTOM;


### PR DESCRIPTION
I extended that library on my own and ran into various issues. Many were related to the fact that the views that are added to the WindowManager are not hardware accelerated. This is a fix for it. 
More information if you like: https://vickychijwani.me/why-is-hardware-acceleration-not-working-on-my-view/